### PR TITLE
MYSTATS-5633 Add privacy manifest

### DIFF
--- a/ATInternet-Apple-SDK-AppExtension.podspec
+++ b/ATInternet-Apple-SDK-AppExtension.podspec
@@ -9,10 +9,11 @@ Pod::Spec.new do |s|
 	s.requires_arc = true
 	s.source = { :git => "https://github.com/bbc/atinternet-apple-sdk.git", :tag => s.version}
 	s.module_name = 'TrackerAppExtension'
-	s.ios.deployment_target	= '11.0'
+	s.swift_version = '5.0'
+	s.ios.deployment_target	= '13.0'
 	s.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-DAT_EXTENSION' }
 	s.source_files = "ATInternetTracker/Sources/*.{h,m,swift}"
 	s.exclude_files = ["ATInternetTracker/Sources/BackgroundTask.swift","ATInternetTracker/Sources/Debugger.swift","ATInternetTracker/Sources/TrackerTests-Bridging-Header.h"]
-	s.platform = :ios, "11.0"
+	s.platform = :ios, "13.0"
 	s.resources = "ATInternetTracker/Sources/DefaultConfiguration*", "ATInternetTracker/Sources/TrackerBundle.bundle"
 end

--- a/ATInternet-Apple-SDK-AppExtension.podspec
+++ b/ATInternet-Apple-SDK-AppExtension.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name = "ATInternet-Apple-SDK-AppExtension"
-	s.version = '2.23.10'
+	s.version = '2.23.10-bbc'
 	s.summary = "AT Internet mobile analytics solution for Apple devices"
 	s.homepage = "https://github.com/bbc/atinternet-apple-sdk"
 	s.documentation_url	= 'https://developers.atinternet-solutions.com/apple-en/getting-started-apple-en/operating-principle-apple-en/'

--- a/ATInternet-Apple-SDK-AppExtension.podspec
+++ b/ATInternet-Apple-SDK-AppExtension.podspec
@@ -15,5 +15,5 @@ Pod::Spec.new do |s|
 	s.source_files = "ATInternetTracker/Sources/*.{h,m,swift}"
 	s.exclude_files = ["ATInternetTracker/Sources/BackgroundTask.swift","ATInternetTracker/Sources/Debugger.swift","ATInternetTracker/Sources/TrackerTests-Bridging-Header.h"]
 	s.platform = :ios, "13.0"
-	s.resources = "ATInternetTracker/Sources/DefaultConfiguration*", "ATInternetTracker/Sources/TrackerBundle.bundle"
+	s.resource_bundles = {"ATInternet-Apple-SDK-AppExtension" => ["ATInternetTracker/Sources/DefaultConfiguration*", "ATInternetTracker/Sources/TrackerBundle.bundle", "ATInternetTracker/Sources/PrivacyInfo.xcprivacy"]}
 end

--- a/ATInternet-Apple-SDK-AppExtension.podspec
+++ b/ATInternet-Apple-SDK-AppExtension.podspec
@@ -15,5 +15,6 @@ Pod::Spec.new do |s|
 	s.source_files = "ATInternetTracker/Sources/*.{h,m,swift}"
 	s.exclude_files = ["ATInternetTracker/Sources/BackgroundTask.swift","ATInternetTracker/Sources/Debugger.swift","ATInternetTracker/Sources/TrackerTests-Bridging-Header.h"]
 	s.platform = :ios, "13.0"
-	s.resource_bundles = {"ATInternet-Apple-SDK-AppExtension" => ["ATInternetTracker/Sources/DefaultConfiguration*", "ATInternetTracker/Sources/TrackerBundle.bundle", "ATInternetTracker/Sources/PrivacyInfo.xcprivacy"]}
+	s.resources = "ATInternetTracker/Sources/DefaultConfiguration*", "ATInternetTracker/Sources/TrackerBundle.bundle"
+	s.resource_bundles = {"ATInternet-Apple-SDK-AppExtension" => ["ATInternetTracker/Sources/PrivacyInfo.xcprivacy"]}
 end

--- a/ATInternet-Apple-SDK-AppExtension.podspec
+++ b/ATInternet-Apple-SDK-AppExtension.podspec
@@ -2,17 +2,17 @@ Pod::Spec.new do |s|
 	s.name = "ATInternet-Apple-SDK-AppExtension"
 	s.version = '2.23.10'
 	s.summary = "AT Internet mobile analytics solution for Apple devices"
-	s.homepage = "https://github.com/at-internet/atinternet-apple-sdk"
+	s.homepage = "https://github.com/bbc/atinternet-apple-sdk"
 	s.documentation_url	= 'https://developers.atinternet-solutions.com/apple-en/getting-started-apple-en/operating-principle-apple-en/'
 	s.license = "MIT"
 	s.author = "AT Internet"
 	s.requires_arc = true
-	s.source = { :git => "https://github.com/at-internet/atinternet-apple-sdk.git", :tag => s.version}
+	s.source = { :git => "https://github.com/bbc/atinternet-apple-sdk.git", :tag => s.version}
 	s.module_name = 'TrackerAppExtension'
-	s.ios.deployment_target	= '10.0'
+	s.ios.deployment_target	= '11.0'
 	s.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-DAT_EXTENSION' }
 	s.source_files = "ATInternetTracker/Sources/*.{h,m,swift}"
 	s.exclude_files = ["ATInternetTracker/Sources/BackgroundTask.swift","ATInternetTracker/Sources/Debugger.swift","ATInternetTracker/Sources/TrackerTests-Bridging-Header.h"]
-	s.platform = :ios, "10.0"
+	s.platform = :ios, "11.0"
 	s.resources = "ATInternetTracker/Sources/DefaultConfiguration*", "ATInternetTracker/Sources/TrackerBundle.bundle"
 end

--- a/ATInternet-Apple-SDK.podspec
+++ b/ATInternet-Apple-SDK.podspec
@@ -13,32 +13,33 @@ Pod::Spec.new do |s|
 	s.ios.deployment_target	= '13.0'
 	s.tvos.deployment_target = '13.0'
 	s.watchos.deployment_target = '3.0'
-
+	s.resource_bundles = {"ATInternet-Apple-SDK" => ["ATInternetTracker/Sources/PrivacyInfo.xcprivacy"]}
+	
 	s.subspec 'Tracker' do |tracker|
 		tracker.source_files = "ATInternetTracker/Sources/*.{h,m,swift}"
-        tracker.resources = "ATInternetTracker/Sources/DefaultConfiguration*", "ATInternetTracker/Sources/TrackerBundle.bundle"
+		tracker.resources = "ATInternetTracker/Sources/DefaultConfiguration*", "ATInternetTracker/Sources/TrackerBundle.bundle"
 		tracker.platform = :ios
 	end
 
 	s.subspec 'AppExtension' do |appExt|
-        appExt.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-DAT_EXTENSION' }
-        appExt.source_files = "ATInternetTracker/Sources/*.{h,m,swift}"
-        appExt.exclude_files = ["ATInternetTracker/Sources/BackgroundTask.swift","ATInternetTracker/Sources/Debugger.swift","ATInternetTracker/Sources/TrackerTests-Bridging-Header.h"]
-        appExt.platform = :ios
-        appExt.resources = "ATInternetTracker/Sources/DefaultConfiguration*", "ATInternetTracker/Sources/TrackerBundle.bundle"
+		appExt.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-DAT_EXTENSION' }
+		appExt.source_files = "ATInternetTracker/Sources/*.{h,m,swift}"
+		appExt.exclude_files = ["ATInternetTracker/Sources/BackgroundTask.swift","ATInternetTracker/Sources/Debugger.swift","ATInternetTracker/Sources/TrackerTests-Bridging-Header.h"]
+		appExt.platform = :ios
+		appExt.resources = "ATInternetTracker/Sources/DefaultConfiguration*", "ATInternetTracker/Sources/TrackerBundle.bundle"
 	end
 
-    s.subspec 'watchOSTracker' do |wos|
-        wos.source_files = "ATInternetTracker/Sources/*.{h,m,swift}"
-        wos.exclude_files = ["ATInternetTracker/Sources/BackgroundTask.swift","ATInternetTracker/Sources/ATReachability.swift","ATInternetTracker/Sources/Debugger.swift","ATInternetTracker/Sources/TrackerTests-Bridging-Header.h"]
-        wos.platform = :watchos
-        wos.resources = "ATInternetTracker/Sources/DefaultConfiguration.plist","ATInternetTracker/Sources/core.manifest.json"
-    end
+	s.subspec 'watchOSTracker' do |wos|
+		wos.source_files = "ATInternetTracker/Sources/*.{h,m,swift}"
+		wos.exclude_files = ["ATInternetTracker/Sources/BackgroundTask.swift","ATInternetTracker/Sources/ATReachability.swift","ATInternetTracker/Sources/Debugger.swift","ATInternetTracker/Sources/TrackerTests-Bridging-Header.h"]
+		wos.platform = :watchos
+		wos.resources = "ATInternetTracker/Sources/DefaultConfiguration.plist","ATInternetTracker/Sources/core.manifest.json"
+	end
 
-    s.subspec 'tvOSTracker' do |tvos|
-        tvos.source_files = "ATInternetTracker/Sources/*.{h,m,swift}"
-        tvos.exclude_files = ["ATInternetTracker/Sources/TrackerTests-Bridging-Header.h", "ATInternetTracker/Sources/watchOSTracker.h"]
-        tvos.resources = "ATInternetTracker/Sources/DefaultConfiguration*", "ATInternetTracker/Sources/TrackerBundle.bundle"
-        tvos.platform = :tvos
-    end
+	s.subspec 'tvOSTracker' do |tvos|
+		tvos.source_files = "ATInternetTracker/Sources/*.{h,m,swift}"
+		tvos.exclude_files = ["ATInternetTracker/Sources/TrackerTests-Bridging-Header.h", "ATInternetTracker/Sources/watchOSTracker.h"]
+		tvos.resources = "ATInternetTracker/Sources/DefaultConfiguration*", "ATInternetTracker/Sources/TrackerBundle.bundle"
+		tvos.platform = :tvos
+	end
 end

--- a/ATInternet-Apple-SDK.podspec
+++ b/ATInternet-Apple-SDK.podspec
@@ -12,7 +12,7 @@ Pod::Spec.new do |s|
 	s.swift_version = '5.0'
 	s.ios.deployment_target	= '13.0'
 	s.tvos.deployment_target = '13.0'
-	s.watchos.deployment_target = '3.0'
+	s.watchos.deployment_target = '6.0'
 	s.resource_bundles = {"ATInternet-Apple-SDK" => ["ATInternetTracker/Sources/PrivacyInfo.xcprivacy"]}
 	
 	s.subspec 'Tracker' do |tracker|

--- a/ATInternet-Apple-SDK.podspec
+++ b/ATInternet-Apple-SDK.podspec
@@ -16,7 +16,8 @@ Pod::Spec.new do |s|
 	
 	s.subspec 'Tracker' do |tracker|
 		tracker.source_files = "ATInternetTracker/Sources/*.{h,m,swift}"
-		tracker.resource_bundles = {"Tracker" => ["ATInternetTracker/Sources/DefaultConfiguration*", "ATInternetTracker/Sources/TrackerBundle.bundle", "ATInternetTracker/Sources/PrivacyInfo.xcprivacy"]}
+		tracker.resources = "ATInternetTracker/Sources/DefaultConfiguration*", "ATInternetTracker/Sources/TrackerBundle.bundle"
+		tracker.resource_bundles = {"Tracker" => ["ATInternetTracker/Sources/PrivacyInfo.xcprivacy"]}
 		tracker.platform = :ios
 	end
 	
@@ -25,20 +26,23 @@ Pod::Spec.new do |s|
 		appExt.source_files = "ATInternetTracker/Sources/*.{h,m,swift}"
 		appExt.exclude_files = ["ATInternetTracker/Sources/BackgroundTask.swift","ATInternetTracker/Sources/Debugger.swift","ATInternetTracker/Sources/TrackerTests-Bridging-Header.h"]
 		appExt.platform = :ios
-		appExt.resource_bundles = {"TrackerExtension" => ["ATInternetTracker/Sources/DefaultConfiguration*", "ATInternetTracker/Sources/TrackerBundle.bundle", "ATInternetTracker/Sources/PrivacyInfo.xcprivacy"]}
+		appExt.resources = "ATInternetTracker/Sources/DefaultConfiguration*", "ATInternetTracker/Sources/TrackerBundle.bundle"
+		appExt.resource_bundles = {"TrackerExtension" => ["ATInternetTracker/Sources/PrivacyInfo.xcprivacy"]}
 	end
 	
 	s.subspec 'watchOSTracker' do |wos|
 		wos.source_files = "ATInternetTracker/Sources/*.{h,m,swift}"
 		wos.exclude_files = ["ATInternetTracker/Sources/BackgroundTask.swift","ATInternetTracker/Sources/ATReachability.swift","ATInternetTracker/Sources/Debugger.swift","ATInternetTracker/Sources/TrackerTests-Bridging-Header.h"]
 		wos.platform = :watchos
-		wos.resource_bundles = {"watchOSTracker" => ["ATInternetTracker/Sources/DefaultConfiguration.plist","ATInternetTracker/Sources/core.manifest.json", "ATInternetTracker/Sources/PrivacyInfo.xcprivacy"]}
+		wos.resources = "ATInternetTracker/Sources/DefaultConfiguration.plist","ATInternetTracker/Sources/core.manifest.json"
+		wos.resource_bundles = {"watchOSTracker" => ["ATInternetTracker/Sources/PrivacyInfo.xcprivacy"]}
 	end
 	
 	s.subspec 'tvOSTracker' do |tvos|
 		tvos.source_files = "ATInternetTracker/Sources/*.{h,m,swift}"
 		tvos.exclude_files = ["ATInternetTracker/Sources/TrackerTests-Bridging-Header.h", "ATInternetTracker/Sources/watchOSTracker.h"]
 		tvos.platform = :tvos
-		tvos.resource_bundles = {"tvOSTracker" => ["ATInternetTracker/Sources/DefaultConfiguration*", "ATInternetTracker/Sources/TrackerBundle.bundle", "ATInternetTracker/Sources/PrivacyInfo.xcprivacy"]}
+		tvos.resources = "ATInternetTracker/Sources/DefaultConfiguration*", "ATInternetTracker/Sources/TrackerBundle.bundle"
+		tvos.resource_bundles = {"tvOSTracker" => ["ATInternetTracker/Sources/PrivacyInfo.xcprivacy"]}
 	end
 end

--- a/ATInternet-Apple-SDK.podspec
+++ b/ATInternet-Apple-SDK.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
 	s.name = "ATInternet-Apple-SDK"
-	s.version = '2.23.10'
+	s.version = '2.23.10-bbc'
 	s.summary = "AT Internet mobile analytics solution for Apple devices"
 	s.homepage = "https://github.com/bbc/atinternet-apple-sdk"
 	s.documentation_url	= 'https://developers.atinternet-solutions.com/apple-en/getting-started-apple-en/operating-principle-apple-en/'

--- a/ATInternet-Apple-SDK.podspec
+++ b/ATInternet-Apple-SDK.podspec
@@ -2,15 +2,15 @@ Pod::Spec.new do |s|
 	s.name = "ATInternet-Apple-SDK"
 	s.version = '2.23.10'
 	s.summary = "AT Internet mobile analytics solution for Apple devices"
-	s.homepage = "https://github.com/at-internet/atinternet-apple-sdk"
+	s.homepage = "https://github.com/bbc/atinternet-apple-sdk"
 	s.documentation_url	= 'https://developers.atinternet-solutions.com/apple-en/getting-started-apple-en/operating-principle-apple-en/'
 	s.license = "MIT"
 	s.author = "AT Internet"
 	s.requires_arc = true
-	s.source = { :git => "https://github.com/at-internet/atinternet-apple-sdk.git", :tag => s.version}
+	s.source = { :git => "https://github.com/bbc/atinternet-apple-sdk.git", :tag => s.version}
 	s.module_name = 'Tracker'
-	s.ios.deployment_target	= '10.0'
-	s.tvos.deployment_target = '10.0'
+	s.ios.deployment_target	= '11.0'
+	s.tvos.deployment_target = '12.1'
 	s.watchos.deployment_target = '3.0'
 
 	s.subspec 'Tracker' do |tracker|

--- a/ATInternet-Apple-SDK.podspec
+++ b/ATInternet-Apple-SDK.podspec
@@ -9,8 +9,9 @@ Pod::Spec.new do |s|
 	s.requires_arc = true
 	s.source = { :git => "https://github.com/bbc/atinternet-apple-sdk.git", :tag => s.version}
 	s.module_name = 'Tracker'
-	s.ios.deployment_target	= '11.0'
-	s.tvos.deployment_target = '12.1'
+	s.swift_version = '5.0'
+	s.ios.deployment_target	= '13.0'
+	s.tvos.deployment_target = '13.0'
 	s.watchos.deployment_target = '3.0'
 
 	s.subspec 'Tracker' do |tracker|

--- a/ATInternet-Apple-SDK.podspec
+++ b/ATInternet-Apple-SDK.podspec
@@ -13,33 +13,32 @@ Pod::Spec.new do |s|
 	s.ios.deployment_target	= '13.0'
 	s.tvos.deployment_target = '13.0'
 	s.watchos.deployment_target = '6.0'
-	s.resource_bundles = {"ATInternet-Apple-SDK" => ["ATInternetTracker/Sources/PrivacyInfo.xcprivacy"]}
 	
 	s.subspec 'Tracker' do |tracker|
 		tracker.source_files = "ATInternetTracker/Sources/*.{h,m,swift}"
-		tracker.resources = "ATInternetTracker/Sources/DefaultConfiguration*", "ATInternetTracker/Sources/TrackerBundle.bundle"
+		tracker.resource_bundles = {"Tracker" => ["ATInternetTracker/Sources/DefaultConfiguration*", "ATInternetTracker/Sources/TrackerBundle.bundle", "ATInternetTracker/Sources/PrivacyInfo.xcprivacy"]}
 		tracker.platform = :ios
 	end
-
+	
 	s.subspec 'AppExtension' do |appExt|
 		appExt.pod_target_xcconfig = { 'OTHER_SWIFT_FLAGS' => '-DAT_EXTENSION' }
 		appExt.source_files = "ATInternetTracker/Sources/*.{h,m,swift}"
 		appExt.exclude_files = ["ATInternetTracker/Sources/BackgroundTask.swift","ATInternetTracker/Sources/Debugger.swift","ATInternetTracker/Sources/TrackerTests-Bridging-Header.h"]
 		appExt.platform = :ios
-		appExt.resources = "ATInternetTracker/Sources/DefaultConfiguration*", "ATInternetTracker/Sources/TrackerBundle.bundle"
+		appExt.resource_bundles = {"TrackerExtension" => ["ATInternetTracker/Sources/DefaultConfiguration*", "ATInternetTracker/Sources/TrackerBundle.bundle", "ATInternetTracker/Sources/PrivacyInfo.xcprivacy"]}
 	end
-
+	
 	s.subspec 'watchOSTracker' do |wos|
 		wos.source_files = "ATInternetTracker/Sources/*.{h,m,swift}"
 		wos.exclude_files = ["ATInternetTracker/Sources/BackgroundTask.swift","ATInternetTracker/Sources/ATReachability.swift","ATInternetTracker/Sources/Debugger.swift","ATInternetTracker/Sources/TrackerTests-Bridging-Header.h"]
 		wos.platform = :watchos
-		wos.resources = "ATInternetTracker/Sources/DefaultConfiguration.plist","ATInternetTracker/Sources/core.manifest.json"
+		wos.resource_bundles = {"watchOSTracker" => ["ATInternetTracker/Sources/DefaultConfiguration.plist","ATInternetTracker/Sources/core.manifest.json", "ATInternetTracker/Sources/PrivacyInfo.xcprivacy"]}
 	end
-
+	
 	s.subspec 'tvOSTracker' do |tvos|
 		tvos.source_files = "ATInternetTracker/Sources/*.{h,m,swift}"
 		tvos.exclude_files = ["ATInternetTracker/Sources/TrackerTests-Bridging-Header.h", "ATInternetTracker/Sources/watchOSTracker.h"]
-		tvos.resources = "ATInternetTracker/Sources/DefaultConfiguration*", "ATInternetTracker/Sources/TrackerBundle.bundle"
 		tvos.platform = :tvos
+		tvos.resource_bundles = {"tvOSTracker" => ["ATInternetTracker/Sources/DefaultConfiguration*", "ATInternetTracker/Sources/TrackerBundle.bundle", "ATInternetTracker/Sources/PrivacyInfo.xcprivacy"]}
 	end
 end

--- a/ATInternetTracker/ATInternetTracker.xcodeproj/project.pbxproj
+++ b/ATInternetTracker/ATInternetTracker.xcodeproj/project.pbxproj
@@ -13,6 +13,10 @@
 		1311F4E82B31C45300162280 /* URLExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1311F4E42B31C45300162280 /* URLExtension.swift */; };
 		1311F4E92B31C45300162280 /* URLExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1311F4E42B31C45300162280 /* URLExtension.swift */; };
 		1311F4EA2B31C45300162280 /* URLExtension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1311F4E42B31C45300162280 /* URLExtension.swift */; };
+		49B941682BDF954B00EA0343 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 49B941672BDF954B00EA0343 /* PrivacyInfo.xcprivacy */; };
+		49B941692BDF954B00EA0343 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 49B941672BDF954B00EA0343 /* PrivacyInfo.xcprivacy */; };
+		49B9416A2BDF954B00EA0343 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 49B941672BDF954B00EA0343 /* PrivacyInfo.xcprivacy */; };
+		49B9416B2BDF954B00EA0343 /* PrivacyInfo.xcprivacy in Resources */ = {isa = PBXBuildFile; fileRef = 49B941672BDF954B00EA0343 /* PrivacyInfo.xcprivacy */; };
 		4F47A3E21D351E8100702747 /* Tracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 4F47A3E11D351E8100702747 /* Tracker.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		4F47A4471D3541C500702747 /* ATInternet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F47A4461D3541C500702747 /* ATInternet.swift */; };
 		4F47A4481D3541C500702747 /* ATInternet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F47A4461D3541C500702747 /* ATInternet.swift */; };
@@ -554,6 +558,7 @@
 
 /* Begin PBXFileReference section */
 		1311F4E42B31C45300162280 /* URLExtension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLExtension.swift; sourceTree = "<group>"; };
+		49B941672BDF954B00EA0343 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		4F47A3DE1D351E8100702747 /* Tracker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Tracker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4F47A3E11D351E8100702747 /* Tracker.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Tracker.h; sourceTree = "<group>"; };
 		4F47A3F91D351EA700702747 /* tvOSTracker.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = tvOSTracker.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -771,6 +776,7 @@
 				CCC9F5F823B639C10055516B /* AVInsights */,
 				CC704B2621B58A0A00114A86 /* Ecommerce */,
 				4F47A4461D3541C500702747 /* ATInternet.swift */,
+				49B941672BDF954B00EA0343 /* PrivacyInfo.xcprivacy */,
 				4F47A5591D36209900702747 /* Asset */,
 				4F47A4961D3542DF00702747 /* Core */,
 				4F47A4971D35433300702747 /* Debugger */,
@@ -1217,6 +1223,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				49B941682BDF954B00EA0343 /* PrivacyInfo.xcprivacy in Resources */,
 				4F47A56D1D3620E800702747 /* DefaultConfiguration~ipod.plist in Resources */,
 				8E7AD14420D2C834000FDB08 /* TrackerBundle.bundle in Resources */,
 				4F47A5681D3620E800702747 /* DefaultConfiguration~iphone.plist in Resources */,
@@ -1229,6 +1236,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				49B9416A2BDF954B00EA0343 /* PrivacyInfo.xcprivacy in Resources */,
 				4F47A5601D3620E800702747 /* DefaultConfiguration.plist in Resources */,
 				8E7AD14620D2C834000FDB08 /* TrackerBundle.bundle in Resources */,
 			);
@@ -1238,6 +1246,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				49B9416B2BDF954B00EA0343 /* PrivacyInfo.xcprivacy in Resources */,
 				4F47A5611D3620E800702747 /* DefaultConfiguration.plist in Resources */,
 				8E7AD14720D2C834000FDB08 /* TrackerBundle.bundle in Resources */,
 			);
@@ -1247,6 +1256,7 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				49B941692BDF954B00EA0343 /* PrivacyInfo.xcprivacy in Resources */,
 				8E7AD14520D2C834000FDB08 /* TrackerBundle.bundle in Resources */,
 				4F47A5641D3620E800702747 /* DefaultConfiguration~ipad.plist in Resources */,
 				4F47A56E1D3620E800702747 /* DefaultConfiguration~ipod.plist in Resources */,
@@ -1863,16 +1873,16 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				ONLY_ACTIVE_ARCH = NO;
 				RESOURCES_TARGETED_DEVICE_FAMILY = "";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TVOS_DEPLOYMENT_TARGET = 12.0;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 				VERSIONING_SYSTEM = "apple-generic";
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 6.0;
 			};
 			name = Debug;
 		};
@@ -1914,17 +1924,17 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				RESOURCES_TARGETED_DEVICE_FAMILY = "";
 				SDKROOT = iphoneos;
 				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				TVOS_DEPLOYMENT_TARGET = 12.0;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
-				WATCHOS_DEPLOYMENT_TARGET = 2.0;
+				WATCHOS_DEPLOYMENT_TARGET = 6.0;
 			};
 			name = Release;
 		};
@@ -1979,7 +1989,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = "Sources/Info-iOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 2.23.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -2041,7 +2051,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = "Sources/Info-iOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 2.23.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
@@ -2108,6 +2118,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = "Sources/Info-tvOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 1.20.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -2121,7 +2132,7 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 10.0;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
@@ -2171,6 +2182,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = "Sources/Info-tvOS.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 1.20.10;
 				MTL_ENABLE_DEBUG_INFO = NO;
@@ -2182,7 +2194,7 @@
 				SUPPORTED_PLATFORMS = "appletvsimulator appletvos";
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
-				TVOS_DEPLOYMENT_TARGET = 10.0;
+				TVOS_DEPLOYMENT_TARGET = 13.0;
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
@@ -2254,7 +2266,7 @@
 				TARGETED_DEVICE_FAMILY = 4;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
-				WATCHOS_DEPLOYMENT_TARGET = 3.0;
+				WATCHOS_DEPLOYMENT_TARGET = 6.0;
 			};
 			name = Debug;
 		};
@@ -2316,7 +2328,7 @@
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
-				WATCHOS_DEPLOYMENT_TARGET = 3.0;
+				WATCHOS_DEPLOYMENT_TARGET = 6.0;
 			};
 			name = Release;
 		};
@@ -2370,7 +2382,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = "Sources/Info-iOS-Extension.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 2.23.10;
 				MTL_ENABLE_DEBUG_INFO = YES;
@@ -2438,7 +2450,7 @@
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				INFOPLIST_FILE = "Sources/Info-iOS-Extension.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 10.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				MARKETING_VERSION = 2.23.10;
 				MTL_ENABLE_DEBUG_INFO = NO;

--- a/ATInternetTracker/Sources/ATInternet.swift
+++ b/ATInternetTracker/Sources/ATInternet.swift
@@ -155,7 +155,6 @@ public class ATInternet: NSObject {
     }
     
     /// Disable user identification.
-    @available(*, deprecated, message: "")
     @objc public class var optOut: Bool {
         get {
             return TechnicalContext.optOut

--- a/ATInternetTracker/Sources/PrivacyInfo.xcprivacy
+++ b/ATInternetTracker/Sources/PrivacyInfo.xcprivacy
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyTracking</key>
+	<false/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeProductInteraction</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+			</array>
+		</dict>
+		<dict>
+			<key>NSPrivacyCollectedDataType</key>
+			<string>NSPrivacyCollectedDataTypeOtherUsageData</string>
+			<key>NSPrivacyCollectedDataTypeLinked</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypeTracking</key>
+			<true/>
+			<key>NSPrivacyCollectedDataTypePurposes</key>
+			<array>
+				<string></string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/ATInternetTracker/Tests/BuilderTests.swift
+++ b/ATInternetTracker/Tests/BuilderTests.swift
@@ -332,7 +332,7 @@ class BuilderTests: XCTestCase, TrackerDelegate {
         
         let builder = Builder(tracker: self.tracker)
         
-        var strings = builder.prepareQuery()
+        let strings = builder.prepareQuery()
         
         XCTAssert(strings["p"]?.0 == "&p=home", "le premier paramètre doit être égal à &p=home")
         XCTAssert(strings["stc"]?.0 == "&stc=chou,patate,carotte", "le second paramètre doit être égal à &stc=chou,patate,carotte")
@@ -361,7 +361,7 @@ class BuilderTests: XCTestCase, TrackerDelegate {
         
         let builder = Builder(tracker: self.tracker)
         
-        var strings = builder.prepareQuery()
+        let strings = builder.prepareQuery()
         
         XCTAssert(strings["p"]?.0 == "&p=home", "le premier paramètre doit être égal à &p=home")
         XCTAssert(strings["stc"]?.0 == "&stc=chou,patate,carotte", "le second paramètre doit être égal à &stc=chou,patate,carotte")
@@ -390,7 +390,7 @@ class BuilderTests: XCTestCase, TrackerDelegate {
         
         let builder = Builder(tracker: self.tracker)
         
-        var strings = builder.prepareQuery()
+        let strings = builder.prepareQuery()
         
         XCTAssert(strings["p"]?.0 == "&p=home", "le premier paramètre doit être égal à &p=home")
         XCTAssert(strings["stc"]?.0 == "&stc=chou,patate,carotte", "le second paramètre doit être égal à &stc=chou,patate,carotte")
@@ -433,7 +433,7 @@ class BuilderTests: XCTestCase, TrackerDelegate {
         var buffer = [String:Param]()
         builder.persistentParameters.forEach { (k,v) in buffer[k] = v }
         builder.volatileParameters.forEach { (k,v) in buffer[k] = v }
-        var params = builder.organizeParameters(buffer)
+        let params = builder.organizeParameters(buffer)
         
         XCTAssert(params[0].key == "p", "Le premier paramètre doit etre p")
         XCTAssert(params[params.count-2].key == "crash", "L'avant dernier paramètre doit etre crash")

--- a/ATInternetTracker/Tests/MediaPlayerTests.swift
+++ b/ATInternetTracker/Tests/MediaPlayerTests.swift
@@ -59,14 +59,14 @@ class MediaPlayerTests: XCTestCase {
     func testRemoveAllMediaPlayers() {
         _ = mediaPlayers.add()
         _ = mediaPlayers.add()
-        _ = mediaPlayers.removeAll()
+        mediaPlayers.removeAll()
         
         XCTAssert(mediaPlayers.playerIds.count == 0, "Le nombre d'objet doit être égale à 2")
     }
     
     func testRemoveMediaPlayer() {
         _ = mediaPlayers.add(72)
-        _ = mediaPlayers.remove(72)
+        mediaPlayers.remove(72)
         
         XCTAssert(mediaPlayers.playerIds.count == 0, "Le nombre d'objet doit être égale à 2")
     }

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The AT Internet tag allows you to follow your users activity throughout your app
 To help you, the tag makes available classes (helpers) enabling the quick implementation of tracking for different application events (screen loads, gestures, video plays…)
 
 ### Requirements
-iOS 11.0+ or tvOS 12.1+ or watchOS 3.0
+iOS 13.0+ or tvOS 13.0+ or watchOS 6.0
 
 Supported devices : 
 * iPhone 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ The AT Internet tag allows you to follow your users activity throughout your app
 To help you, the tag makes available classes (helpers) enabling the quick implementation of tracking for different application events (screen loads, gestures, video plays…)
 
 ### Requirements
-iOS 10.0+ or tvOS 10.0+ or watchOS 3.0
+iOS 11.0+ or tvOS 12.1+ or watchOS 3.0
 
 Supported devices : 
 * iPhone 


### PR DESCRIPTION
# BAU
This PR adds a privacy manifest to ATInternet-Apple-SDK.

Changes:
- Privacy manifest added

It relates to:  
[MYSTATS-5633 - Echo iOS - Add privacy manifest](https://jira.dev.bbc.co.uk/browse/MYSTATS-5633)

Related PRs
[Hendricks iOS Integration](https://github.com/bbc/hendricks-ios-integration/pull/132)
[Echo Client iOS Swift](https://github.com/bbc/echo-client-ios-swift/pull/278)
[ATI Internet SDK](https://github.com/bbc/atinternet-apple-sdk/pull/1)